### PR TITLE
change rjb normal dependency instead of development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in twkorean.gemspec
 gemspec
-gem 'rjb'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Or install it yourself as:
 ## Required
 
     $ export JAVA_HOME={Your Path}
-    $ gem install 'rjb'
 
 ## Test
     

--- a/twkorean.gemspec
+++ b/twkorean.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rjb"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rjb"
   spec.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
rjb 로딩 오류가 나서 디펜던시 부분 수정하였습니다. @jun85664396 
```
/Users/yuzong/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `require': cannot load such file -- rjb (LoadError)
```